### PR TITLE
be more specific about OSGi bundle exports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -615,16 +615,21 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>
+              org.fcrepo.camel;version=${project.version},
+              org.fcrepo.camel.processor;version=${project.version}
+            </Export-Package>
+            <Private-Package>
+              javax.ws.rs.*,
               com.hp.hpl.jena.*,
               com.ibm.icu.*,
               org.apache.clerezza.rdf.*,
               org.apache.clerezza.utils.*,
               org.apache.commons.codec.*,
               org.apache.commons.lang3.*,
-              org.apache.jena.*,
+              org.apache.jena.iri.*,
               org.osgi.service.component,
               org.wymiwyg.commons.util.*,
-            </Export-Package>
+            </Private-Package>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
The OSGi configuration should specify version numbers and should not export third-party packages