### PR TITLE
added sesame support to the SparqlProcessor classes

### DIFF
--- a/src/main/java/org/fcrepo/camel/processor/SparqlDeleteProcessor.java
+++ b/src/main/java/org/fcrepo/camel/processor/SparqlDeleteProcessor.java
@@ -56,10 +56,10 @@ public class SparqlDeleteProcessor implements Processor {
          * too many triples from the triplestore. This command does
          * not remove blank nodes.
          */
-        in.setBody("DELETE WHERE { <" + subject + "> ?p ?o };\n" +
+        in.setBody("update=DELETE WHERE { <" + subject + "> ?p ?o };\n" +
                    "DELETE WHERE { <" + subject + "/fcr:export?format=jcr/xml> ?p ?o }");
         in.setHeader(HTTP_METHOD, "POST");
-        in.setHeader(CONTENT_TYPE, "application/sparql-update");
+        in.setHeader(CONTENT_TYPE, "application/x-www-form-urlencoded");
 
    }
 }

--- a/src/main/java/org/fcrepo/camel/processor/SparqlInsertProcessor.java
+++ b/src/main/java/org/fcrepo/camel/processor/SparqlInsertProcessor.java
@@ -56,8 +56,8 @@ public class SparqlInsertProcessor implements Processor {
                 "application/n-triples".equals(contentType) ? "text/rdf+nt" : contentType, null);
         serializer.serialize(serializedGraph, graph.getGraph(), "text/rdf+nt");
 
-        exchange.getIn().setBody("INSERT DATA { " + serializedGraph.toString("UTF-8") + " }");
+        exchange.getIn().setBody("update=INSERT DATA { " + serializedGraph.toString("UTF-8") + " }");
         exchange.getIn().setHeader(HTTP_METHOD, "POST");
-        exchange.getIn().setHeader(CONTENT_TYPE, "application/sparql-update");
+        exchange.getIn().setHeader(CONTENT_TYPE, "application/x-www-form-urlencoded");
     }
 }

--- a/src/main/java/org/fcrepo/camel/processor/SparqlUpdateProcessor.java
+++ b/src/main/java/org/fcrepo/camel/processor/SparqlUpdateProcessor.java
@@ -73,11 +73,11 @@ public class SparqlUpdateProcessor implements Processor {
          * delete too many triples from the triplestore. This command does
          * not delete blank nodes.
          */
-        exchange.getIn().setBody("DELETE WHERE { <" + subject + "> ?p ?o };\n" +
+        exchange.getIn().setBody("update=DELETE WHERE { <" + subject + "> ?p ?o };\n" +
                                  "DELETE WHERE { <" + subject + "/fcr:export?format=jcr/xml> ?p ?o };\n" +
                                  "INSERT { " + serializedGraph.toString("UTF-8") + " }\n" +
                                  "WHERE { }");
         exchange.getIn().setHeader(HTTP_METHOD, "POST");
-        exchange.getIn().setHeader(CONTENT_TYPE, "application/sparql-update");
+        exchange.getIn().setHeader(CONTENT_TYPE, "application/x-www-form-urlencoded");
     }
 }

--- a/src/test/java/org/fcrepo/camel/SparqlDeleteProcessorTest.java
+++ b/src/test/java/org/fcrepo/camel/SparqlDeleteProcessorTest.java
@@ -83,9 +83,9 @@ public class SparqlDeleteProcessorTest extends CamelTestSupport {
 
         // Assertions
         resultEndpoint.expectedBodiesReceived(
-                "DELETE WHERE { <" + base + path + "> ?p ?o };\n" +
+                "update=DELETE WHERE { <" + base + path + "> ?p ?o };\n" +
                 "DELETE WHERE { <" + base + path + "/fcr:export?format=jcr/xml> ?p ?o }");
-        resultEndpoint.expectedHeaderReceived(Exchange.CONTENT_TYPE, "application/sparql-update");
+        resultEndpoint.expectedHeaderReceived(Exchange.CONTENT_TYPE, "application/x-www-form-urlencoded");
         resultEndpoint.expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
 
         // Test

--- a/src/test/java/org/fcrepo/camel/SparqlInsertProcessorTest.java
+++ b/src/test/java/org/fcrepo/camel/SparqlInsertProcessorTest.java
@@ -61,8 +61,8 @@ public class SparqlInsertProcessorTest extends CamelTestSupport {
         reverse(lines);
 
         // Assertions
-        resultEndpoint.expectedBodiesReceived("INSERT DATA { " + join(lines, " ") + " }");
-        resultEndpoint.expectedHeaderReceived("Content-Type", "application/sparql-update");
+        resultEndpoint.expectedBodiesReceived("update=INSERT DATA { " + join(lines, " ") + " }");
+        resultEndpoint.expectedHeaderReceived("Content-Type", "application/x-www-form-urlencoded");
         resultEndpoint.expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
 
         // Test

--- a/src/test/java/org/fcrepo/camel/SparqlUpdateProcessorTest.java
+++ b/src/test/java/org/fcrepo/camel/SparqlUpdateProcessorTest.java
@@ -62,11 +62,11 @@ public class SparqlUpdateProcessorTest extends CamelTestSupport {
 
         // Assertions
         resultEndpoint.expectedBodiesReceived(
-                  "DELETE WHERE { <" + base + path + "> ?p ?o }; " +
+                  "update=DELETE WHERE { <" + base + path + "> ?p ?o }; " +
                   "DELETE WHERE { <" + base + path + "/fcr:export?format=jcr/xml> ?p ?o }; " +
                   "INSERT { " + join(lines, " ") + " } " +
                   "WHERE { }");
-        resultEndpoint.expectedHeaderReceived("Content-Type", "application/sparql-update");
+        resultEndpoint.expectedHeaderReceived("Content-Type", "application/x-www-form-urlencoded");
         resultEndpoint.expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
 
         // Test

--- a/src/test/java/org/fcrepo/camel/integration/FcrepoSparqlIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FcrepoSparqlIT.java
@@ -99,7 +99,7 @@ public class FcrepoSparqlIT extends CamelTestSupport {
         sparqlQueryEndpoint.expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 200);
 
         sparqlUpdateEndpoint.expectedMessageCount(1);
-        sparqlUpdateEndpoint.expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 204);
+        sparqlUpdateEndpoint.expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 200);
 
         deletedEndpoint.expectedMessageCount(2);
         deletedEndpoint.expectedBodiesReceived(null, null);
@@ -142,13 +142,13 @@ public class FcrepoSparqlIT extends CamelTestSupport {
     public void testInsertDeleteSparql() throws Exception {
         // Assertions
         resultEndpoint.expectedMessageCount(1);
-        resultEndpoint.expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 204);
+        resultEndpoint.expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 200);
 
         sparqlQueryEndpoint.expectedMessageCount(6);
         sparqlQueryEndpoint.expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 200);
 
         sparqlUpdateEndpoint.expectedMessageCount(4);
-        sparqlUpdateEndpoint.expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 204);
+        sparqlUpdateEndpoint.expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 200);
 
         deletedEndpoint.expectedMessageCount(2);
         deletedEndpoint.expectedBodiesReceived(null, null);


### PR DESCRIPTION
https://jira.duraspace.org/browse/FCREPO-1270

This changes the processed message body to follow the form "update=<COMMANDS>" so that these classes will work with both fuseki and sesame (fuseki is not as strict about what it accepts). The corresponding ContentType header is also updated to use "application/x-www-form-urlencoded" which is supported by both triplestores.