### PR TITLE
added support for prefer headers along with unit and integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Fcrepo Component
 
 The **fcrepo:** component provides access to an external
 [Fedora4](http://fcrepo.org) Object
-[API](https://wiki.duraspace.org/display/FF/RESTful+HTTP+API+-+Containers)
+[API](https://wiki.duraspace.org/display/FEDORA40/RESTful+HTTP+API+-+Containers)
 for use with [Apache Camel](https://camel.apache.org).
 
 [![Build Status](https://travis-ci.org/fcrepo4-labs/fcrepo-camel.png?branch=master)](https://travis-ci.org/fcrepo4-labs/fcrepo-camel)
@@ -74,12 +74,23 @@ Message headers
 | `Exchange.HTTP_METHOD` | `String` | The HTTP method to use |
 | `Exchange.CONTENT_TYPE` | `String` | The ContentType of the resource. This sets the `Content-Type` header, but this value can be overridden directly on the endpoint. |
 | `Exchange.ACCEPT_CONTENT_TYPE` | `String` | This sets the `Accept` header, but this value can be overridden directly on the endpoint. |
-| `FcrepoHeaders.HTTP_PREFER`  | `String` | This sets the `Prefer` header on a repository request. The full header value should be declared here, and it will override any value set directly on an endpoint. |
+| `FcrepoHeaders.FCREPO_PREFER`  | `String` | This sets the `Prefer` header on a repository request. The full header value should be declared here, and it will override any value set directly on an endpoint. |
 | `FcrepoHeaders.FCREPO_IDENTIFIER`    | `String` | The resource path, appended to the endpoint uri. |
 | `FcrepoHeaders.FCREPO_BASE_URL`      | `String` | The base url used for accessing Fedora. |
 | `FcrepoHeaders.FCREPO_TRANSFORM`     | `String` | The named `fcr:transform` method to use. This value overrides any value set explicitly on the endpoint. |
 
-The `fcrepo` component will also accept message headers produced directly by fedora, particularly the `org.fcrepo.jms.identifier` header. It will use that header only when `FEDORA_IDENTIFIER` is not defined.
+The `fcrepo` component will also accept message headers produced directly by fedora, particularly the `org.fcrepo.jms.identifier` header. It will use that header only when `CamelFcrepoIdentifier` is not defined.
+
+If these headers are used with the Spring DSL or with the Simple language, the header values can be used directly with the following values:
+
+| Name    | Value |
+| ------- | ----- |
+| `FcrepoHeaders.FCREPO_BASE_URL` | `CamelFcrepoBaseUrl` |
+| `FcrepoHeaders.FCREPO_IDENTIFIER` | `CamelFcrepoIdentifier` |
+| `FcrepoHeaders.FCREPO_TRANSFORM` | `CamelFcrepoTransform` |
+| `FcrepoHeaders.FCREPO_PREFER` | `CamelFcrepoPrefer` |
+
+These headers can be removed as a group like this in the Java DSL: `removeHeaders("CamelFcrepo*")`
 
 Message body
 ------------

--- a/README.md
+++ b/README.md
@@ -25,15 +25,16 @@ FcrepoEndpoint options
 | `accept` | `null` | Set the `Accept` header for content negotiation |
 | `metadata` | `true`  | Whether GET requests should retrieve RDF descriptions of non-RDF content  |
 | `transform` | `null` | If set, this defines the transform used for the given object. This should be used in the context of GET or POST. For GET requests, the value should be the name of the transform (e.g. `default`). For POST requests, the value can simply be `true`. Using this causes the `Accept` header to be set as `application/json`. |
+| `preferOmit` | `null` | If set, this populates the `Prefer:` HTTP header with omitted values. For single values, the standard [LDP values](http://www.w3.org/TR/ldp/#prefer-parameters) and the corresponding [Fcrepo extensions](https://wiki.duraspace.org/display/FEDORA40/RESTful+HTTP+API+-+Containers#RESTfulHTTPAPI-Containers-GETRetrievethecontentoftheresource) can be provided in short form (without the namespace). |
+| `preferInclude` | `null` | If set, this populates the `Prefer:` HTTP header with included values. For single values, the standard [LDP values](http://www.w3.org/TR/ldp/#prefer-parameters) and the corresponding [Fcrepo extensions](https://wiki.duraspace.org/display/FEDORA40/RESTful+HTTP+API+-+Containers#RESTfulHTTPAPI-Containers-GETRetrievethecontentoftheresource) can be provided in short form (without the namespace). |
 | `throwExceptionOnFailure` | `true` | Option to disable throwing the HttpOperationFailedException in case of failed responses from the remote server. This allows you to get all responses regardless of the HTTP status code. |
-
 
 Examples
 --------
 
 A simple example for sending messages to an external Solr service:
 
-    XPathBuilder xpath = new XPathBuilder("/rdf:RDF/rdf:Description/rdf:type[@rdf:resource='http://fedora.info/definitions/v4/repository#Indexable']");
+    XPathBuilder xpath = new XPathBuilder("/rdf:RDF/rdf:Description/rdf:type[@rdf:resource='http://fedora.info/definitions/v4/indexing#indexable']");
     xpath.namespace("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#");
 
     from("activemq:topic:fedora")
@@ -48,7 +49,7 @@ Or, using the Spring DSL:
       <from uri="activemq:topic:fedora"/>
       <to uri="fcrepo:localhost:8080/rest"/>
       <filter>
-        <xpath>/rdf:RDF/rdf:Description/rdf:type[@rdf:resource='http://fedora.info/definitions/v4/repository#Indexable']</xpath>
+        <xpath>/rdf:RDF/rdf:Description/rdf:type[@rdf:resource='http://fedora.info/definitions/v4/indexing#indexable']</xpath>
         <to uri="fcrepo:localhost:8080/rest?transform=mytransform"/>
         <to uri="http4:solr-host:8080/solr/core/update"/>
       </filter>
@@ -73,9 +74,10 @@ Message headers
 | `Exchange.HTTP_METHOD` | `String` | The HTTP method to use |
 | `Exchange.CONTENT_TYPE` | `String` | The ContentType of the resource. This sets the `Content-Type` header, but this value can be overridden directly on the endpoint. |
 | `Exchange.ACCEPT_CONTENT_TYPE` | `String` | This sets the `Accept` header, but this value can be overridden directly on the endpoint. |
-| `FCREPO_IDENTIFIER`    | `String` | The resource path, appended to the endpoint uri. |
-| `FCREPO_BASE_URL`      | `String` | The base url used for accessing Fedora. |
-| `FCREPO_TRANSFORM`     | `String` | The named `fcr:transform` method to use. This value overrides any value set explicitly on the endpoint. |
+| `FcrepoHeaders.HTTP_PREFER`  | `String` | This sets the `Prefer` header on a repository request. The full header value should be declared here, and it will override any value set directly on an endpoint. |
+| `FcrepoHeaders.FCREPO_IDENTIFIER`    | `String` | The resource path, appended to the endpoint uri. |
+| `FcrepoHeaders.FCREPO_BASE_URL`      | `String` | The base url used for accessing Fedora. |
+| `FcrepoHeaders.FCREPO_TRANSFORM`     | `String` | The named `fcr:transform` method to use. This value overrides any value set explicitly on the endpoint. |
 
 The `fcrepo` component will also accept message headers produced directly by fedora, particularly the `org.fcrepo.jms.identifier` header. It will use that header only when `FEDORA_IDENTIFIER` is not defined.
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
     <clerezza.rdf.jena.serializer.version>0.11</clerezza.rdf.jena.serializer.version>
     <clerezza.rdf.jena.parser.version>0.12</clerezza.rdf.jena.parser.version>
     <clerezza.rdf.core.version>0.14</clerezza.rdf.core.version>
+    <guava.version>18.0</guava.version>
     <!-- plugins -->
     <checkstyle.plugin.version>2.12.1</checkstyle.plugin.version>
     <!-- values -->
@@ -139,6 +140,12 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>${commons.io.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
     </dependency>
 
     <dependency>
@@ -615,8 +622,15 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>
+              org.fcrepo.camel;version=${project.version},
+              org.fcrepo.camel.processor;version=${project.version}
+            </Export-Package>
+            <Private-Package>
+              com.google.common.*,
+              com.google.thirdparty.publicsuffix.*,
               com.hp.hpl.jena.*,
               com.ibm.icu.*,
+              javax.ws.rs.*,
               org.apache.clerezza.rdf.*,
               org.apache.clerezza.utils.*,
               org.apache.commons.codec.*,
@@ -624,7 +638,7 @@
               org.apache.jena.*,
               org.osgi.service.component,
               org.wymiwyg.commons.util.*,
-            </Export-Package>
+            </Private-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/src/main/java/org/fcrepo/camel/FcrepoClient.java
+++ b/src/main/java/org/fcrepo/camel/FcrepoClient.java
@@ -235,13 +235,17 @@ public class FcrepoClient {
      * @param url the URL of the resource to fetch
      * @param accept the requested MIMEType of the resource to be retrieved
      */
-    public FcrepoResponse get(final URI url, final String accept)
+    public FcrepoResponse get(final URI url, final String accept, final String prefer)
             throws IOException, HttpOperationFailedException {
 
         final HttpGet request = new HttpGet(url);
 
         if (accept != null) {
             request.setHeader("Accept", accept);
+        }
+
+        if (prefer != null) {
+            request.setHeader("Prefer", prefer);
         }
 
         final HttpResponse response = httpclient.execute(request);

--- a/src/main/java/org/fcrepo/camel/FcrepoEndpoint.java
+++ b/src/main/java/org/fcrepo/camel/FcrepoEndpoint.java
@@ -63,6 +63,12 @@ public class FcrepoEndpoint extends DefaultEndpoint {
     @UriParam
     private Boolean throwExceptionOnFailure = true;
 
+    @UriParam
+    private String preferInclude = null;
+
+    @UriParam
+    private String preferOmit = null;
+
     /**
      * Create a FcrepoEndpoint with a uri, path and component
      * @param uri the endpoint uri (without path values)
@@ -264,5 +270,37 @@ public class FcrepoEndpoint extends DefaultEndpoint {
     @ManagedAttribute(description = "Whether to use the /fcr:tombstone endpoint on objects")
     public Boolean getTombstone() {
         return tombstone;
+    }
+
+    /**
+     * preferInclude setter
+     */
+    @ManagedAttribute(description = "Whether to include a Prefer: return=representation; include=\"URI\" header")
+    public void setPreferInclude(final String include) {
+        this.preferInclude = include;
+    }
+
+    /**
+     * preferOmit getter
+     */
+    @ManagedAttribute(description = "Whether to include a Prefer: return=representation; include=\"URI\" header")
+    public String getPreferInclude() {
+        return preferInclude;
+    }
+
+    /**
+     * preferOmit setter
+     */
+    @ManagedAttribute(description = "Whether to include a Prefer: return=representation; omit=\"URI\" header")
+    public void setPreferOmit(final String omit) {
+        this.preferOmit = omit;
+    }
+
+    /**
+     * preferOmit getter
+     */
+    @ManagedAttribute(description = "Whether to include a Prefer: return=representation; omit=\"URI\" header")
+    public String getPreferOmit() {
+        return preferOmit;
     }
 }

--- a/src/main/java/org/fcrepo/camel/FcrepoHeaders.java
+++ b/src/main/java/org/fcrepo/camel/FcrepoHeaders.java
@@ -26,6 +26,8 @@ public final class FcrepoHeaders {
 
     public static final String FCREPO_TRANSFORM = "FCREPO_TRANSFORM";
 
+    public static final String HTTP_PREFER = "CamelHttpPrefer";
+
     private FcrepoHeaders() {
         // prevent instantiation
     }

--- a/src/main/java/org/fcrepo/camel/FcrepoHeaders.java
+++ b/src/main/java/org/fcrepo/camel/FcrepoHeaders.java
@@ -20,13 +20,13 @@ package org.fcrepo.camel;
  */
 public final class FcrepoHeaders {
 
-    public static final String FCREPO_BASE_URL = "FCREPO_BASE_URL";
+    public static final String FCREPO_BASE_URL = "CamelFcrepoBaseUrl";
 
-    public static final String FCREPO_IDENTIFIER = "FCREPO_IDENTIFIER";
+    public static final String FCREPO_IDENTIFIER = "CamelFcrepoIdentifier";
 
-    public static final String FCREPO_TRANSFORM = "FCREPO_TRANSFORM";
+    public static final String FCREPO_TRANSFORM = "CamelFcrepoTransform";
 
-    public static final String HTTP_PREFER = "CamelHttpPrefer";
+    public static final String FCREPO_PREFER = "CamelFcrepoPrefer";
 
     private FcrepoHeaders() {
         // prevent instantiation

--- a/src/main/java/org/fcrepo/camel/FcrepoProducer.java
+++ b/src/main/java/org/fcrepo/camel/FcrepoProducer.java
@@ -118,7 +118,7 @@ public class FcrepoProducer extends DefaultProducer {
     /**
      * Retrieve the resource location from a HEAD request.
      */
-    protected URI getMetadataUri(final String url)
+    private URI getMetadataUri(final String url)
             throws HttpOperationFailedException, IOException {
         final FcrepoResponse headResponse = client.head(URI.create(url));
         if (headResponse.getLocation() != null) {
@@ -135,7 +135,7 @@ public class FcrepoProducer extends DefaultProducer {
      *
      * @param exchange the incoming message exchange
      */
-    protected HttpMethods getMethod(final Exchange exchange) {
+    private HttpMethods getMethod(final Exchange exchange) {
         final HttpMethods method = exchange.getIn().getHeader(Exchange.HTTP_METHOD, HttpMethods.class);
         if (method == null) {
             return HttpMethods.GET;
@@ -150,7 +150,7 @@ public class FcrepoProducer extends DefaultProducer {
      *
      * @param exchange the incoming message exchange
      */
-    protected String getContentType(final Exchange exchange) {
+    private String getContentType(final Exchange exchange) {
         final String contentTypeString = ExchangeHelper.getContentType(exchange);
         if (!isBlank(endpoint.getContentType())) {
             return endpoint.getContentType();
@@ -169,7 +169,7 @@ public class FcrepoProducer extends DefaultProducer {
      *
      * @param exchange the incoming message exchange
      */
-    protected String getAccept(final Exchange exchange) {
+    private String getAccept(final Exchange exchange) {
         final Message in = exchange.getIn();
         final String fcrepoTransform = in.getHeader(FcrepoHeaders.FCREPO_TRANSFORM, String.class);
 
@@ -193,7 +193,7 @@ public class FcrepoProducer extends DefaultProducer {
      *
      * @param exchange the incoming message exchange
      */
-    protected String getUrl(final Exchange exchange) {
+    private String getUrl(final Exchange exchange) {
         final Message in = exchange.getIn();
         final HttpMethods method = getMethod(exchange);
         final URI baseUri = URI.create(endpoint.getBaseUrl());
@@ -228,12 +228,12 @@ public class FcrepoProducer extends DefaultProducer {
      *
      *  @param exchange the incoming message exchange
      */
-    protected String getPrefer(final Exchange exchange) {
+    private String getPrefer(final Exchange exchange) {
         final Message in = exchange.getIn();
 
         if (getMethod(exchange) == HttpMethods.GET) {
-            if (!isBlank(in.getHeader(FcrepoHeaders.HTTP_PREFER, String.class))) {
-                return in.getHeader(FcrepoHeaders.HTTP_PREFER, String.class);
+            if (!isBlank(in.getHeader(FcrepoHeaders.FCREPO_PREFER, String.class))) {
+                return in.getHeader(FcrepoHeaders.FCREPO_PREFER, String.class);
             } else {
                 return buildPreferHeader(endpoint.getPreferInclude(), endpoint.getPreferOmit());
             }

--- a/src/main/java/org/fcrepo/camel/RdfNamespaces.java
+++ b/src/main/java/org/fcrepo/camel/RdfNamespaces.java
@@ -16,6 +16,10 @@
 
 package org.fcrepo.camel;
 
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
 /**
  * @author acoburn
  */
@@ -28,6 +32,20 @@ public final class RdfNamespaces {
     public static final String RDF = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
 
     public static final String LDP = "http://www.w3.org/ns/ldp#";
+
+    public static final String SERVER_MANAGED = REPOSITORY + "ServerManaged";
+
+    public static final String EMBED_RESOURCES = REPOSITORY + "EmbedResources";
+
+    public static final String INBOUND_REFERENCES = REPOSITORY + "InboundReferences";
+
+    public static final Map<String, String> PREFER_PROPERTIES = ImmutableMap.<String, String>builder()
+        .put("PreferContainment", LDP + "PreferContainment")
+        .put("PreferMembership", LDP + "PreferMembership")
+        .put("PreferMinimalContainer", LDP + "PreferMinimalContainer")
+        .put("ServerManaged", SERVER_MANAGED)
+        .put("EmbedResources", EMBED_RESOURCES)
+        .put("InboundReferences", INBOUND_REFERENCES).build();
 
     private RdfNamespaces() {
         // Prevent instantiation

--- a/src/main/java/org/fcrepo/camel/RdfNamespaces.java
+++ b/src/main/java/org/fcrepo/camel/RdfNamespaces.java
@@ -33,19 +33,13 @@ public final class RdfNamespaces {
 
     public static final String LDP = "http://www.w3.org/ns/ldp#";
 
-    public static final String SERVER_MANAGED = REPOSITORY + "ServerManaged";
-
-    public static final String EMBED_RESOURCES = REPOSITORY + "EmbedResources";
-
-    public static final String INBOUND_REFERENCES = REPOSITORY + "InboundReferences";
-
     public static final Map<String, String> PREFER_PROPERTIES = ImmutableMap.<String, String>builder()
         .put("PreferContainment", LDP + "PreferContainment")
         .put("PreferMembership", LDP + "PreferMembership")
         .put("PreferMinimalContainer", LDP + "PreferMinimalContainer")
-        .put("ServerManaged", SERVER_MANAGED)
-        .put("EmbedResources", EMBED_RESOURCES)
-        .put("InboundReferences", INBOUND_REFERENCES).build();
+        .put("ServerManaged", REPOSITORY + "ServerManaged")
+        .put("EmbedResources", REPOSITORY + "EmbedResources")
+        .put("InboundReferences", REPOSITORY + "InboundReferences").build();
 
     private RdfNamespaces() {
         // Prevent instantiation

--- a/src/test/java/org/fcrepo/camel/FcrepoClientAuthTest.java
+++ b/src/test/java/org/fcrepo/camel/FcrepoClientAuthTest.java
@@ -70,7 +70,7 @@ public class FcrepoClientAuthTest {
         entity.setContentType(RDF_XML);
         doSetupMockRequest(RDF_XML, entity, status);
 
-        final FcrepoResponse response = testClient.get(uri, RDF_XML);
+        final FcrepoResponse response = testClient.get(uri, RDF_XML, null);
 
         assertEquals(response.getUrl(), uri);
         assertEquals(response.getStatusCode(), status);
@@ -90,7 +90,7 @@ public class FcrepoClientAuthTest {
         entity.setContentType(RDF_XML);
         doSetupMockRequest(RDF_XML, entity, status);
 
-        final FcrepoResponse response = testClient.get(uri, RDF_XML);
+        final FcrepoResponse response = testClient.get(uri, RDF_XML, null);
 
         assertEquals(response.getUrl(), uri);
         assertEquals(response.getStatusCode(), status);
@@ -110,7 +110,7 @@ public class FcrepoClientAuthTest {
         entity.setContentType(RDF_XML);
         doSetupMockRequest(RDF_XML, entity, status);
 
-        final FcrepoResponse response = testClient.get(uri, RDF_XML);
+        final FcrepoResponse response = testClient.get(uri, RDF_XML, null);
 
         assertEquals(response.getUrl(), uri);
         assertEquals(response.getStatusCode(), status);

--- a/src/test/java/org/fcrepo/camel/FcrepoClientErrorTest.java
+++ b/src/test/java/org/fcrepo/camel/FcrepoClientErrorTest.java
@@ -80,7 +80,7 @@ public class FcrepoClientErrorTest {
         entity.setContentType(RDF_XML);
         doSetupMockRequest(RDF_XML, entity, status);
 
-        final FcrepoResponse response = testClient.get(uri, RDF_XML);
+        final FcrepoResponse response = testClient.get(uri, RDF_XML, null);
 
         assertEquals(response.getUrl(), uri);
         assertEquals(response.getStatusCode(), status);
@@ -98,7 +98,7 @@ public class FcrepoClientErrorTest {
         entity.setContentType(RDF_XML);
         doSetupMockRequest(RDF_XML, entity, status);
 
-        final FcrepoResponse response = testClient.get(uri, RDF_XML);
+        final FcrepoResponse response = testClient.get(uri, RDF_XML, "return=representation;");
 
         assertEquals(response.getUrl(), uri);
         assertEquals(response.getStatusCode(), status);

--- a/src/test/java/org/fcrepo/camel/FcrepoClientTest.java
+++ b/src/test/java/org/fcrepo/camel/FcrepoClientTest.java
@@ -80,7 +80,7 @@ public class FcrepoClientTest {
 
         doSetupMockRequest(RDF_XML, entity, status);
 
-        final FcrepoResponse response = testClient.get(uri, RDF_XML);
+        final FcrepoResponse response = testClient.get(uri, RDF_XML, "return=minimal");
 
         assertEquals(response.getUrl(), uri);
         assertEquals(response.getStatusCode(), status);
@@ -97,7 +97,7 @@ public class FcrepoClientTest {
         entity.setContentType(RDF_XML);
 
         doSetupMockRequest(RDF_XML, entity, status);
-        testClient.get(uri, RDF_XML);
+        testClient.get(uri, RDF_XML, "return=representation");
     }
 
     @Test (expected = HttpOperationFailedException.class)
@@ -108,7 +108,7 @@ public class FcrepoClientTest {
         entity.setContentType(RDF_XML);
 
         doSetupMockRequest(RDF_XML, entity, status);
-        testClient.get(uri, RDF_XML);
+        testClient.get(uri, RDF_XML, null);
     }
 
     @Test
@@ -122,7 +122,7 @@ public class FcrepoClientTest {
 
         when(mockResponse.getHeaders("Link")).thenReturn(headers);
 
-        final FcrepoResponse response = testClient.get(uri, RDF_XML);
+        final FcrepoResponse response = testClient.get(uri, RDF_XML, null);
 
         assertEquals(response.getUrl(), uri);
         assertEquals(response.getStatusCode(), status);
@@ -138,7 +138,7 @@ public class FcrepoClientTest {
 
         doSetupMockRequest(RDF_XML, null, status);
 
-        final FcrepoResponse response = testClient.get(uri, null);
+        final FcrepoResponse response = testClient.get(uri, null, null);
 
         assertEquals(response.getUrl(), uri);
         assertEquals(response.getStatusCode(), status);

--- a/src/test/java/org/fcrepo/camel/FcrepoConstantsTest.java
+++ b/src/test/java/org/fcrepo/camel/FcrepoConstantsTest.java
@@ -44,9 +44,10 @@ public class FcrepoConstantsTest {
 
     @Test
     public void testFcrepoHeaders() {
-        assertEquals(FcrepoHeaders.FCREPO_BASE_URL, "FCREPO_BASE_URL");
-        assertEquals(FcrepoHeaders.FCREPO_IDENTIFIER, "FCREPO_IDENTIFIER");
-        assertEquals(FcrepoHeaders.FCREPO_TRANSFORM, "FCREPO_TRANSFORM");
+        assertEquals(FcrepoHeaders.FCREPO_BASE_URL, "CamelFcrepoBaseUrl");
+        assertEquals(FcrepoHeaders.FCREPO_IDENTIFIER, "CamelFcrepoIdentifier");
+        assertEquals(FcrepoHeaders.FCREPO_TRANSFORM, "CamelFcrepoTransform");
+        assertEquals(FcrepoHeaders.FCREPO_PREFER, "CamelFcrepoPrefer");
     }
 
     @Test

--- a/src/test/java/org/fcrepo/camel/FcrepoEndpointTest.java
+++ b/src/test/java/org/fcrepo/camel/FcrepoEndpointTest.java
@@ -158,6 +158,39 @@ public class FcrepoEndpointTest {
     }
 
     @Test
+    public void testPreferOmit() {
+        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext);
+        final String omit1 = "PreferContainment";
+        final String omit2 = "http://www.w3.org/ns/ldp#PreferMembership";
+        final String omit3 = "http://www.w3.org/ns/ldp#PreferMinimalContainer " +
+                             "http://www.w3.org/ns/ldp#PreferContainment";
+        assertEquals(null, testEndpoint.getPreferOmit());
+        testEndpoint.setPreferOmit(omit1);
+        assertEquals(omit1, testEndpoint.getPreferOmit());
+        testEndpoint.setPreferOmit(omit2);
+        assertEquals(omit2, testEndpoint.getPreferOmit());
+        testEndpoint.setPreferOmit(omit3);
+        assertEquals(omit3, testEndpoint.getPreferOmit());
+    }
+
+    @Test
+    public void testPreferInclude() {
+        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext);
+        final String include1 = "PreferContainment";
+        final String include2 = "http://www.w3.org/ns/ldp#PreferMembership";
+        final String include3 = "http://www.w3.org/ns/ldp#PreferMinimalContainer " +
+                                "http://www.w3.org/ns/ldp#PreferContainment";
+        assertEquals(null, testEndpoint.getPreferInclude());
+        testEndpoint.setPreferInclude(include1);
+        assertEquals(include1, testEndpoint.getPreferInclude());
+        testEndpoint.setPreferInclude(include2);
+        assertEquals(include2, testEndpoint.getPreferInclude());
+        testEndpoint.setPreferInclude(include3);
+        assertEquals(include3, testEndpoint.getPreferInclude());
+    }
+
+
+    @Test
     public void testSingleton() {
         final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext);
         assertEquals(true, testEndpoint.isSingleton());

--- a/src/test/java/org/fcrepo/camel/FcrepoProducerTest.java
+++ b/src/test/java/org/fcrepo/camel/FcrepoProducerTest.java
@@ -121,7 +121,7 @@ public class FcrepoProducerTest {
         init();
 
         testExchange.getIn().setHeader(FcrepoHeaders.FCREPO_IDENTIFIER, "/foo");
-        testExchange.getIn().setHeader(FcrepoHeaders.HTTP_PREFER, prefer);
+        testExchange.getIn().setHeader(FcrepoHeaders.FCREPO_PREFER, prefer);
 
         when(mockClient.head(any(URI.class))).thenReturn(headResponse);
         when(mockClient.get(any(URI.class), any(String.class), eq(prefer))).thenReturn(getResponse);
@@ -610,12 +610,14 @@ public class FcrepoProducerTest {
         testProducer = new FcrepoProducer(testEndpoint);
 
         assertEquals(6, RdfNamespaces.PREFER_PROPERTIES.size());
-        assertEquals(RdfNamespaces.SERVER_MANAGED, RdfNamespaces.PREFER_PROPERTIES.get("ServerManaged"));
-        assertEquals(RdfNamespaces.EMBED_RESOURCES, RdfNamespaces.PREFER_PROPERTIES.get("EmbedResources"));
-        assertEquals(RdfNamespaces.INBOUND_REFERENCES, RdfNamespaces.PREFER_PROPERTIES.get("InboundReferences"));
+        final String[] fcrepoPrefer = new String[] { "ServerManaged", "EmbedResources", "InboundReferences" };
+        for (final String s : fcrepoPrefer) {
+            assertEquals(RdfNamespaces.REPOSITORY + s, RdfNamespaces.PREFER_PROPERTIES.get(s));
+        }
+
         final String[] ldpPrefer = new String[] { "PreferContainment", "PreferMembership",
             "PreferMinimalContainer" };
-        for (final String s : ldpPrefer ) {
+        for (final String s : ldpPrefer) {
             assertEquals(RdfNamespaces.LDP + s, RdfNamespaces.PREFER_PROPERTIES.get(s));
         }
     }

--- a/src/test/java/org/fcrepo/camel/FcrepoProducerTest.java
+++ b/src/test/java/org/fcrepo/camel/FcrepoProducerTest.java
@@ -80,7 +80,7 @@ public class FcrepoProducerTest {
         testExchange.getIn().setHeader(FcrepoHeaders.FCREPO_IDENTIFIER, "/foo");
 
         when(mockClient.head(any(URI.class))).thenReturn(headResponse);
-        when(mockClient.get(any(URI.class), eq(TestUtils.RDF_XML))).thenReturn(getResponse);
+        when(mockClient.get(any(URI.class), eq(TestUtils.RDF_XML), any(String.class))).thenReturn(getResponse);
 
         testProducer.process(testExchange);
 
@@ -102,7 +102,123 @@ public class FcrepoProducerTest {
         testExchange.getIn().setHeader("Accept", TestUtils.N_TRIPLES);
 
         when(mockClient.head(any(URI.class))).thenReturn(headResponse);
-        when(mockClient.get(any(URI.class), eq(TestUtils.N_TRIPLES))).thenReturn(getResponse);
+        when(mockClient.get(any(URI.class), eq(TestUtils.N_TRIPLES), any(String.class))).thenReturn(getResponse);
+
+        testProducer.process(testExchange);
+
+        assertEquals(testExchange.getIn().getBody(String.class), TestUtils.rdfTriples);
+        assertEquals(testExchange.getIn().getHeader(Exchange.CONTENT_TYPE, String.class), TestUtils.N_TRIPLES);
+    }
+
+    @Test
+    public void testGetPreferHeaderProducer() throws Exception {
+        final URI uri = create(TestUtils.baseUrl);
+        final ByteArrayInputStream body = new ByteArrayInputStream(TestUtils.rdfTriples.getBytes());
+        final FcrepoResponse headResponse = new FcrepoResponse(uri, 200, null, null, null);
+        final FcrepoResponse getResponse = new FcrepoResponse(uri, 200, TestUtils.N_TRIPLES, null, body);
+        final String prefer = "return=representation; omit=\"http://www.w3.org/ns/ldp#PreferContainment\";";
+
+        init();
+
+        testExchange.getIn().setHeader(FcrepoHeaders.FCREPO_IDENTIFIER, "/foo");
+        testExchange.getIn().setHeader(FcrepoHeaders.HTTP_PREFER, prefer);
+
+        when(mockClient.head(any(URI.class))).thenReturn(headResponse);
+        when(mockClient.get(any(URI.class), any(String.class), eq(prefer))).thenReturn(getResponse);
+
+        testProducer.process(testExchange);
+
+        assertEquals(testExchange.getIn().getBody(String.class), TestUtils.rdfTriples);
+        assertEquals(testExchange.getIn().getHeader(Exchange.CONTENT_TYPE, String.class), TestUtils.N_TRIPLES);
+    }
+
+    @Test
+    public void testGetPreferIncludeLongEndpointProducer() throws Exception {
+        final URI uri = create(TestUtils.baseUrl);
+        final ByteArrayInputStream body = new ByteArrayInputStream(TestUtils.rdfTriples.getBytes());
+        final FcrepoResponse headResponse = new FcrepoResponse(uri, 200, null, null, null);
+        final FcrepoResponse getResponse = new FcrepoResponse(uri, 200, TestUtils.N_TRIPLES, null, body);
+        final String prefer = "return=representation; " +
+                    "include=\"http://fedora.info/definitions/v4/repository#ServerManaged\";";
+
+        testEndpoint.setPreferInclude("http://fedora.info/definitions/v4/repository#ServerManaged");
+
+        init();
+
+        testExchange.getIn().setHeader(FcrepoHeaders.FCREPO_IDENTIFIER, "/foo");
+
+        when(mockClient.head(any(URI.class))).thenReturn(headResponse);
+        when(mockClient.get(any(URI.class), any(String.class), eq(prefer))).thenReturn(getResponse);
+
+        testProducer.process(testExchange);
+
+        assertEquals(testExchange.getIn().getBody(String.class), TestUtils.rdfTriples);
+        assertEquals(testExchange.getIn().getHeader(Exchange.CONTENT_TYPE, String.class), TestUtils.N_TRIPLES);
+    }
+
+    @Test
+    public void testGetPreferIncludeShortEndpointProducer() throws Exception {
+        final URI uri = create(TestUtils.baseUrl);
+        final ByteArrayInputStream body = new ByteArrayInputStream(TestUtils.rdfTriples.getBytes());
+        final FcrepoResponse headResponse = new FcrepoResponse(uri, 200, null, null, null);
+        final FcrepoResponse getResponse = new FcrepoResponse(uri, 200, TestUtils.N_TRIPLES, null, body);
+        final String prefer = "return=representation; include=\"http://www.w3.org/ns/ldp#PreferMembership\";";
+
+        testEndpoint.setPreferInclude("PreferMembership");
+
+        init();
+
+        testExchange.getIn().setHeader(FcrepoHeaders.FCREPO_IDENTIFIER, "/foo");
+
+        when(mockClient.head(any(URI.class))).thenReturn(headResponse);
+        when(mockClient.get(any(URI.class), any(String.class), eq(prefer))).thenReturn(getResponse);
+
+        testProducer.process(testExchange);
+
+        assertEquals(testExchange.getIn().getBody(String.class), TestUtils.rdfTriples);
+        assertEquals(testExchange.getIn().getHeader(Exchange.CONTENT_TYPE, String.class), TestUtils.N_TRIPLES);
+    }
+
+    @Test
+    public void testGetPreferOmitLongEndpointProducer() throws Exception {
+        final URI uri = create(TestUtils.baseUrl);
+        final ByteArrayInputStream body = new ByteArrayInputStream(TestUtils.rdfTriples.getBytes());
+        final FcrepoResponse headResponse = new FcrepoResponse(uri, 200, null, null, null);
+        final FcrepoResponse getResponse = new FcrepoResponse(uri, 200, TestUtils.N_TRIPLES, null, body);
+        final String prefer = "return=representation; " +
+                    "omit=\"http://fedora.info/definitions/v4/repository#EmbedResources\";";
+
+        testEndpoint.setPreferOmit("http://fedora.info/definitions/v4/repository#EmbedResources");
+
+        init();
+
+        testExchange.getIn().setHeader(FcrepoHeaders.FCREPO_IDENTIFIER, "/foo");
+
+        when(mockClient.head(any(URI.class))).thenReturn(headResponse);
+        when(mockClient.get(any(URI.class), any(String.class), eq(prefer))).thenReturn(getResponse);
+
+        testProducer.process(testExchange);
+
+        assertEquals(testExchange.getIn().getBody(String.class), TestUtils.rdfTriples);
+        assertEquals(testExchange.getIn().getHeader(Exchange.CONTENT_TYPE, String.class), TestUtils.N_TRIPLES);
+    }
+
+    @Test
+    public void testGetPreferOmitShortEndpointProducer() throws Exception {
+        final URI uri = create(TestUtils.baseUrl);
+        final ByteArrayInputStream body = new ByteArrayInputStream(TestUtils.rdfTriples.getBytes());
+        final FcrepoResponse headResponse = new FcrepoResponse(uri, 200, null, null, null);
+        final FcrepoResponse getResponse = new FcrepoResponse(uri, 200, TestUtils.N_TRIPLES, null, body);
+        final String prefer = "return=representation; omit=\"http://www.w3.org/ns/ldp#PreferContainment\";";
+
+        testEndpoint.setPreferOmit("PreferContainment");
+
+        init();
+
+        testExchange.getIn().setHeader(FcrepoHeaders.FCREPO_IDENTIFIER, "/foo");
+
+        when(mockClient.head(any(URI.class))).thenReturn(headResponse);
+        when(mockClient.get(any(URI.class), any(String.class), eq(prefer))).thenReturn(getResponse);
 
         testProducer.process(testExchange);
 
@@ -124,7 +240,7 @@ public class FcrepoProducerTest {
         testExchange.getIn().setHeader(FcrepoHeaders.FCREPO_IDENTIFIER, "/foo");
 
         when(mockClient.head(any(URI.class))).thenReturn(headResponse);
-        when(mockClient.get(any(URI.class), eq(TestUtils.N_TRIPLES))).thenReturn(getResponse);
+        when(mockClient.get(any(URI.class), eq(TestUtils.N_TRIPLES), any(String.class))).thenReturn(getResponse);
 
         testProducer.process(testExchange);
 
@@ -142,7 +258,7 @@ public class FcrepoProducerTest {
         init();
 
         when(mockClient.head(any(URI.class))).thenReturn(headResponse);
-        when(mockClient.get(any(URI.class), eq(TestUtils.RDF_XML))).thenReturn(getResponse);
+        when(mockClient.get(any(URI.class), eq(TestUtils.RDF_XML), any(String.class))).thenReturn(getResponse);
 
         testProducer.process(testExchange);
 
@@ -165,7 +281,7 @@ public class FcrepoProducerTest {
         testExchange.getIn().setHeader(Exchange.ACCEPT_CONTENT_TYPE, TestUtils.TEXT_PLAIN);
         testExchange.getIn().setHeader(Exchange.HTTP_METHOD, HttpMethods.GET);
 
-        when(mockClient.get(any(URI.class), eq(TestUtils.TEXT_PLAIN))).thenReturn(getResponse);
+        when(mockClient.get(any(URI.class), eq(TestUtils.TEXT_PLAIN), any(String.class))).thenReturn(getResponse);
 
         testProducer.process(testExchange);
 
@@ -252,7 +368,7 @@ public class FcrepoProducerTest {
         testExchange.getIn().setHeader(Exchange.HTTP_METHOD, HttpMethods.GET);
 
         when(mockClient.head(any(URI.class))).thenReturn(headResponse);
-        when(mockClient.get(create(TestUtils.baseUrl + "/fcr:transform/default"), TestUtils.JSON))
+        when(mockClient.get(create(TestUtils.baseUrl + "/fcr:transform/default"), TestUtils.JSON, null))
             .thenReturn(getResponse);
 
         testProducer.process(testExchange);
@@ -309,7 +425,7 @@ public class FcrepoProducerTest {
         testExchange.getIn().setHeader(FcrepoHeaders.FCREPO_TRANSFORM, "default");
 
         when(mockClient.head(any(URI.class))).thenReturn(headResponse);
-        when(mockClient.get(create(TestUtils.baseUrl + "/fcr:transform/default"), TestUtils.JSON))
+        when(mockClient.get(create(TestUtils.baseUrl + "/fcr:transform/default"), TestUtils.JSON, null))
             .thenReturn(getResponse);
 
         testProducer.process(testExchange);
@@ -335,7 +451,7 @@ public class FcrepoProducerTest {
         testExchange.getIn().setHeader(FcrepoHeaders.FCREPO_TRANSFORM, "default");
 
         when(mockClient.head(any(URI.class))).thenReturn(headResponse);
-        when(mockClient.get(create(TestUtils.baseUrl + "/fcr:transform/default"), TestUtils.JSON))
+        when(mockClient.get(create(TestUtils.baseUrl + "/fcr:transform/default"), TestUtils.JSON, null))
             .thenReturn(getResponse);
 
         testProducer.process(testExchange);
@@ -362,7 +478,7 @@ public class FcrepoProducerTest {
         testExchange.getIn().setHeader(FcrepoHeaders.FCREPO_IDENTIFIER, "/foo");
 
         when(mockClient.head(any(URI.class))).thenReturn(headResponse);
-        when(mockClient.get(create(TestUtils.baseUrl + "/fcr:transform/default"), TestUtils.JSON))
+        when(mockClient.get(create(TestUtils.baseUrl + "/fcr:transform/default"), TestUtils.JSON, null))
             .thenReturn(getResponse);
 
         testProducer.process(testExchange);
@@ -487,5 +603,20 @@ public class FcrepoProducerTest {
         assertEquals(testExchange.getIn().getBody(String.class), TestUtils.baseUrl);
         assertEquals(testExchange.getIn().getHeader(Exchange.HTTP_RESPONSE_CODE), status);
         assertEquals(testExchange.getIn().getHeader(Exchange.CONTENT_TYPE), TestUtils.TEXT_PLAIN);
+    }
+
+    @Test
+    public void testPreferProperties() throws Exception {
+        testProducer = new FcrepoProducer(testEndpoint);
+
+        assertEquals(6, RdfNamespaces.PREFER_PROPERTIES.size());
+        assertEquals(RdfNamespaces.SERVER_MANAGED, RdfNamespaces.PREFER_PROPERTIES.get("ServerManaged"));
+        assertEquals(RdfNamespaces.EMBED_RESOURCES, RdfNamespaces.PREFER_PROPERTIES.get("EmbedResources"));
+        assertEquals(RdfNamespaces.INBOUND_REFERENCES, RdfNamespaces.PREFER_PROPERTIES.get("InboundReferences"));
+        final String[] ldpPrefer = new String[] { "PreferContainment", "PreferMembership",
+            "PreferMinimalContainer" };
+        for (final String s : ldpPrefer ) {
+            assertEquals(RdfNamespaces.LDP + s, RdfNamespaces.PREFER_PROPERTIES.get(s));
+        }
     }
 }

--- a/src/test/java/org/fcrepo/camel/integration/FcrepoConstantsIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FcrepoConstantsIT.java
@@ -47,5 +47,8 @@ public class FcrepoConstantsIT {
         assertEquals(RdfNamespaces.INDEXING, RdfLexicon.INDEXING_NAMESPACE);
         assertEquals(RdfNamespaces.RDF, RdfLexicon.RDF_NAMESPACE);
         assertEquals(RdfNamespaces.LDP, RdfLexicon.LDP_NAMESPACE);
+        assertEquals(RdfNamespaces.REPOSITORY + "ServerManaged", RdfLexicon.SERVER_MANAGED.toString());
+        assertEquals(RdfNamespaces.REPOSITORY + "EmbedResources", RdfLexicon.EMBED_CONTAINS.toString());
+        assertEquals(RdfNamespaces.REPOSITORY + "InboundReferences", RdfLexicon.INBOUND_REFERENCES.toString());
     }
 }

--- a/src/test/java/org/fcrepo/camel/integration/FcrepoContainerPreferIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FcrepoContainerPreferIT.java
@@ -1,0 +1,249 @@
+/**
+ * Copyright 2014 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.camel.integration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.builder.xml.Namespaces;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.fcrepo.camel.FcrepoHeaders;
+import org.fcrepo.camel.JmsHeaders;
+import org.fcrepo.camel.RdfNamespaces;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Test adding an RDF resource
+ * @author Aaron Coburn
+ * @since Dec 26, 2014
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration({"/spring-test/test-container.xml"})
+public class FcrepoContainerPreferIT extends CamelTestSupport {
+
+    @EndpointInject(uri = "mock:created")
+    protected MockEndpoint createdEndpoint;
+
+    @EndpointInject(uri = "mock:filter")
+    protected MockEndpoint filteredEndpoint;
+
+    @EndpointInject(uri = "mock:container")
+    protected MockEndpoint containerEndpoint;
+
+    @EndpointInject(uri = "mock:verifyGone")
+    protected MockEndpoint goneEndpoint;
+
+    @EndpointInject(uri = "mock:deleted")
+    protected MockEndpoint deletedEndpoint;
+
+    @EndpointInject(uri = "mock:verifyNotFound")
+    protected MockEndpoint notFoundEndpoint;
+
+    @Produce(uri = "direct:filter")
+    protected ProducerTemplate template;
+
+    @Test
+    public void testGetContainer() throws InterruptedException {
+        // Assertions
+        createdEndpoint.expectedMessageCount(2);
+        createdEndpoint.expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 201);
+
+        containerEndpoint.expectedMessageCount(1);
+        containerEndpoint.expectedHeaderReceived(Exchange.CONTENT_TYPE, "application/rdf+xml");
+        containerEndpoint.expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 200);
+
+        filteredEndpoint.expectedMessageCount(4);
+        filteredEndpoint.expectedHeaderReceived(Exchange.CONTENT_TYPE, "application/rdf+xml");
+        filteredEndpoint.expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 200);
+
+        deletedEndpoint.expectedMessageCount(4);
+        deletedEndpoint.expectedBodiesReceived(null, null, null, null);
+        deletedEndpoint.expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 204);
+
+        goneEndpoint.expectedMessageCount(2);
+        goneEndpoint.expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 410);
+
+        notFoundEndpoint.expectedMessageCount(2);
+        notFoundEndpoint.expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 404);
+
+        final Map<String, Object> headers = new HashMap<>();
+        headers.put(Exchange.HTTP_METHOD, "POST");
+        headers.put(Exchange.CONTENT_TYPE, "text/turtle");
+
+        final String fullPath = template.requestBodyAndHeaders(
+                "direct:create",
+                FcrepoTestUtils.getTurtleDocument(),
+                headers, String.class);
+
+        // Strip off the baseUrl to get the resource path
+        final String identifier = fullPath.replaceAll(FcrepoTestUtils.getFcrepoBaseUrl(), "");
+
+        final String child = "/child";
+
+        headers.clear();
+        headers.put(Exchange.HTTP_METHOD, "PUT");
+        headers.put(Exchange.CONTENT_TYPE, "text/turtle");
+        headers.put(FcrepoHeaders.FCREPO_IDENTIFIER, identifier + child);
+
+        template.sendBodyAndHeaders("direct:create", FcrepoTestUtils.getTurtleDocument(), headers);
+
+        template.sendBodyAndHeader("direct:includeServerManaged", null, FcrepoHeaders.FCREPO_IDENTIFIER,
+                identifier);
+        template.sendBodyAndHeader("direct:includeContainment", null, FcrepoHeaders.FCREPO_IDENTIFIER,
+                identifier);
+
+        template.sendBodyAndHeader("direct:omitServerManaged", null, JmsHeaders.IDENTIFIER,
+                identifier);
+        template.sendBodyAndHeader("direct:omitContainmentShort", null, FcrepoHeaders.FCREPO_IDENTIFIER,
+                identifier);
+        template.sendBodyAndHeader("direct:omitContainmentFull", null, FcrepoHeaders.FCREPO_IDENTIFIER,
+                identifier);
+
+        template.sendBodyAndHeader("direct:includeContainmentOmitManaged", null, FcrepoHeaders.FCREPO_IDENTIFIER,
+                identifier);
+
+        headers.clear();
+        headers.put(FcrepoHeaders.FCREPO_IDENTIFIER, identifier);
+        headers.put(FcrepoHeaders.HTTP_PREFER, "return=representation; " +
+                    "omit=\"http://fedora.info/definitions/v4/repository#ServerManaged\"; " +
+                    "include=\"http://www.w3.org/ns/ldp#PreferContainment\";");
+        template.sendBodyAndHeaders("direct:preferHeadersCheckContainment", null, headers);
+        template.sendBodyAndHeaders("direct:preferHeadersCheckServerManaged", null, headers);
+
+        headers.put(FcrepoHeaders.HTTP_PREFER, "return=representation; " +
+                    "omit=\"http://fedora.info/definitions/v4/repository#ServerManaged " +
+                    "http://www.w3.org/ns/ldp#PreferContainment\"");
+        template.sendBodyAndHeaders("direct:preferHeadersCheckContainment", null, headers);
+        template.sendBodyAndHeaders("direct:preferHeadersCheckServerManaged", null, headers);
+
+        template.sendBodyAndHeader("direct:delete", null, FcrepoHeaders.FCREPO_IDENTIFIER, identifier + child);
+        template.sendBodyAndHeader("direct:delete", null, FcrepoHeaders.FCREPO_IDENTIFIER, identifier);
+
+        // Confirm that assertions passed
+        createdEndpoint.assertIsSatisfied();
+        filteredEndpoint.assertIsSatisfied();
+        containerEndpoint.assertIsSatisfied();
+        goneEndpoint.assertIsSatisfied();
+        notFoundEndpoint.assertIsSatisfied();
+        deletedEndpoint.assertIsSatisfied();
+
+        // Check deleted container
+        for (Exchange exchange : goneEndpoint.getExchanges()) {
+            Assert.assertTrue(exchange.getIn().getHeader(Exchange.CONTENT_TYPE, String.class).contains("text/html"));
+            Assert.assertTrue(exchange.getIn().getBody(String.class).contains("Gone"));
+        }
+
+        for (Exchange exchange : notFoundEndpoint.getExchanges()) {
+            Assert.assertTrue(exchange.getIn().getHeader(Exchange.CONTENT_TYPE, String.class).contains("text/html"));
+            Assert.assertTrue(exchange.getIn().getBody(String.class).contains("Not Found"));
+        }
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() {
+
+                final String fcrepo_uri = FcrepoTestUtils.getFcrepoEndpointUri();
+
+                final Namespaces ns = new Namespaces("rdf", RdfNamespaces.RDF);
+                ns.add("fedora", RdfNamespaces.REPOSITORY);
+                ns.add("ldp", RdfNamespaces.LDP);
+
+                from("direct:create")
+                    .to(fcrepo_uri)
+                    .to("mock:created");
+
+                from("direct:preferHeadersCheckContainment")
+                    .to(fcrepo_uri)
+                    .filter().xpath(
+                        "/rdf:RDF/rdf:Description/ldp:contains", ns)
+                    .to("mock:filter");
+
+                from("direct:preferHeadersCheckServerManaged")
+                    .to(fcrepo_uri)
+                    .filter().xpath(
+                        "/rdf:RDF/rdf:Description/fedora:uuid", ns)
+                    .to("mock:filter");
+
+                from("direct:includeServerManaged")
+                    .to(fcrepo_uri + "?preferInclude=ServerManaged")
+                    .filter().xpath(
+                        "/rdf:RDF/rdf:Description/fedora:uuid", ns)
+                    .to("mock:filter")
+                    .to(fcrepo_uri)
+                    .to("mock:container");
+
+                from("direct:includeContainmentOmitManaged")
+                    .to(fcrepo_uri + "?preferOmit=ServerManaged&preferInclude=PreferContainment")
+                    .filter().xpath(
+                        "/rdf:RDF/rdf:Description/ldp:contains", ns)
+                    .to("mock:filter");
+
+                from("direct:omitServerManaged")
+                    .to(fcrepo_uri + "?preferOmit=ServerManaged")
+                    .filter().xpath(
+                        "/rdf:RDF/rdf:Description/fedora:uuid", ns)
+                    .to("mock:filter")
+                    .to(fcrepo_uri)
+                    .to("mock:container");
+
+                from("direct:includeContainment")
+                    .to(fcrepo_uri + "?preferInclude=PreferContainment")
+                    .filter().xpath(
+                            "/rdf:RDF/rdf:Description/ldp:contains", ns)
+                    .to("mock:filter");
+
+                from("direct:omitContainmentShort")
+                    .to(fcrepo_uri + "?preferOmit=PreferContainment")
+                    .filter().xpath(
+                            "/rdf:RDF/rdf:Description/ldp:contains", ns)
+                    .to("mock:filter");
+
+                from("direct:omitContainmentFull")
+                    .to(fcrepo_uri + "?preferOmit=http://www.w3.org/ns/ldp#PreferContainment")
+                    .filter().xpath(
+                            "/rdf:RDF/rdf:Description/ldp:contains", ns)
+                    .to("mock:filter");
+
+                from("direct:delete")
+                    .setHeader(Exchange.HTTP_METHOD, constant("DELETE"))
+                    .to(fcrepo_uri)
+                    .to("mock:deleted")
+                    .setHeader(Exchange.HTTP_METHOD, constant("GET"))
+                    .to(fcrepo_uri + "?throwExceptionOnFailure=false")
+                    .to("mock:verifyGone")
+                    .setHeader(Exchange.HTTP_METHOD, constant("DELETE"))
+                    .to(fcrepo_uri + "?tombstone=true")
+                    .to("mock:deleted")
+                    .setHeader(Exchange.HTTP_METHOD, constant("GET"))
+                    .to(fcrepo_uri + "?throwExceptionOnFailure=false")
+                    .to("mock:verifyNotFound");
+            }
+        };
+    }
+}

--- a/src/test/java/org/fcrepo/camel/integration/FcrepoContainerPreferIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FcrepoContainerPreferIT.java
@@ -127,13 +127,13 @@ public class FcrepoContainerPreferIT extends CamelTestSupport {
 
         headers.clear();
         headers.put(FcrepoHeaders.FCREPO_IDENTIFIER, identifier);
-        headers.put(FcrepoHeaders.HTTP_PREFER, "return=representation; " +
+        headers.put(FcrepoHeaders.FCREPO_PREFER, "return=representation; " +
                     "omit=\"http://fedora.info/definitions/v4/repository#ServerManaged\"; " +
                     "include=\"http://www.w3.org/ns/ldp#PreferContainment\";");
         template.sendBodyAndHeaders("direct:preferHeadersCheckContainment", null, headers);
         template.sendBodyAndHeaders("direct:preferHeadersCheckServerManaged", null, headers);
 
-        headers.put(FcrepoHeaders.HTTP_PREFER, "return=representation; " +
+        headers.put(FcrepoHeaders.FCREPO_PREFER, "return=representation; " +
                     "omit=\"http://fedora.info/definitions/v4/repository#ServerManaged " +
                     "http://www.w3.org/ns/ldp#PreferContainment\"");
         template.sendBodyAndHeaders("direct:preferHeadersCheckContainment", null, headers);

--- a/src/test/java/org/fcrepo/camel/integration/FcrepoSparqlIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FcrepoSparqlIT.java
@@ -222,7 +222,7 @@ public class FcrepoSparqlIT extends CamelTestSupport {
                     .removeHeaders("CamelHttp*")
                     .setHeader(Exchange.HTTP_QUERY, simple(
                             "query=SELECT * WHERE { " +
-                                "<${headers.FCREPO_BASE_URL}${headers.FCREPO_IDENTIFIER}> " +
+                                "<${headers.CamelFcrepoBaseUrl}${headers.CamelFcrepoIdentifier}> " +
                                 "<" + RdfNamespaces.RDF + "type> ?o }"))
                     .to("http4:" + fuseki_url + "/test/query")
                     .filter(resourceXpath)
@@ -232,7 +232,7 @@ public class FcrepoSparqlIT extends CamelTestSupport {
                     .removeHeaders("CamelHttp*")
                     .setHeader(Exchange.HTTP_QUERY, simple(
                             "query=SELECT * WHERE { " +
-                                "<${headers.FCREPO_BASE_URL}${headers.FCREPO_IDENTIFIER}> " +
+                                "<${headers.CamelFcrepoBaseUrl}${headers.CamelFcrepoIdentifier}> " +
                                 "<" + RdfNamespaces.RDF + "type> ?o }"))
                     .to("http4:" + fuseki_url + "/test/query")
                     .filter(containerXpath)
@@ -242,9 +242,10 @@ public class FcrepoSparqlIT extends CamelTestSupport {
                     .removeHeaders("CamelHttp*")
                     .setHeader(Exchange.HTTP_QUERY, simple(
                             "query=SELECT * WHERE { " +
-                                "<${headers.FCREPO_BASE_URL}${headers.FCREPO_IDENTIFIER}> " +
+                                "<${headers.CamelFcrepoBaseUrl}${headers.CamelFcrepoIdentifier}> " +
                                 "<http://purl.org/dc/elements/1.1/title> ?o }"))
                     .to("http4:" + fuseki_url + "/test/query")
+                    .convertBodyTo(String.class)
                     .filter(titleXpath)
                         .to("mock:sparql.query");
 


### PR DESCRIPTION
This addresses https://jira.duraspace.org/browse/FCREPO-1273

Specifically, it allows users to control the Prefer headers sent to the fedora endpoint