### PR TITLE
java8 support

### DIFF
--- a/src/test/java/org/fcrepo/camel/SparqlInsertProcessorTest.java
+++ b/src/test/java/org/fcrepo/camel/SparqlInsertProcessorTest.java
@@ -16,8 +16,6 @@
 package org.fcrepo.camel;
 
 import static org.apache.commons.lang3.StringUtils.normalizeSpace;
-import static org.apache.commons.lang3.StringUtils.join;
-import static org.apache.commons.lang3.ArrayUtils.reverse;
 import static org.fcrepo.camel.integration.FcrepoTestUtils.getFcrepoEndpointUri;
 import static org.fcrepo.camel.integration.FcrepoTestUtils.getN3Document;
 import static org.fcrepo.camel.integration.FcrepoTestUtils.getTurtleDocument;
@@ -56,12 +54,12 @@ public class SparqlInsertProcessorTest extends CamelTestSupport {
         final String path = "/path/a/b/c/d";
         final String document = getN3Document();
 
-        // Reverse the lines as the RDF is serialized in opposite order
-        final String[] lines = document.split("\n");
-        reverse(lines);
-
         // Assertions
-        resultEndpoint.expectedBodiesReceived("update=INSERT DATA { " + join(lines, " ") + " }");
+        resultEndpoint.allMessages().body().contains("update=INSERT DATA { ");
+        resultEndpoint.allMessages().body().contains(" }");
+        for (final String s : document.split("\n")) {
+            resultEndpoint.expectedBodyReceived().body().contains(s);
+        }
         resultEndpoint.expectedHeaderReceived("Content-Type", "application/x-www-form-urlencoded");
         resultEndpoint.expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
 

--- a/src/test/java/org/fcrepo/camel/integration/FcrepoBinaryHeadIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FcrepoBinaryHeadIT.java
@@ -70,7 +70,7 @@ public class FcrepoBinaryHeadIT extends CamelTestSupport {
         createdEndpoint.expectedMessageCount(2);
         createdEndpoint.expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 201);
 
-        binaryEndpoint.expectedBodiesReceived(null);
+        binaryEndpoint.allMessages().body().equals(null);
         binaryEndpoint.expectedMessageCount(1);
         binaryEndpoint.expectedHeaderReceived(Exchange.CONTENT_TYPE, "text/plain");
         binaryEndpoint.expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 200);
@@ -80,7 +80,7 @@ public class FcrepoBinaryHeadIT extends CamelTestSupport {
         filteredEndpoint.expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 200);
 
         deletedEndpoint.expectedMessageCount(4);
-        deletedEndpoint.expectedBodiesReceived(null, null, null, null);
+        deletedEndpoint.allMessages().body().equals(null);
         deletedEndpoint.expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 204);
 
         goneEndpoint.expectedMessageCount(2);

--- a/src/test/java/org/fcrepo/camel/integration/FcrepoContainerHeadIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FcrepoContainerHeadIT.java
@@ -78,7 +78,7 @@ public class FcrepoContainerHeadIT extends CamelTestSupport {
         filteredEndpoint.expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 200);
 
         deletedEndpoint.expectedMessageCount(4);
-        deletedEndpoint.expectedBodiesReceived(null, null, null, null);
+        deletedEndpoint.allMessages().body().equals(null);
         deletedEndpoint.expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 204);
 
         goneEndpoint.expectedMessageCount(2);


### PR DESCRIPTION
https://jira.duraspace.org/browse/FCREPO-1279

refactored processor tests to support varying serialization orders of RDF triples (the order is different with openjdk 1.8)
refactored HEAD tests to remove ambiguous null value testing