### PR TITLE
removed dependency on jersey for http link header parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
     <mockito.version>1.10.8</mockito.version>
     <slf4j.version>1.7.9</slf4j.version>
     <solr.version>4.10.2</solr.version>
-    <javax.ws.rs.version>2.0.1</javax.ws.rs.version>
     <spring.version>4.0.7.RELEASE</spring.version>
     <clerezza.rdf.jena.serializer.version>0.11</clerezza.rdf.jena.serializer.version>
     <clerezza.rdf.jena.parser.version>0.12</clerezza.rdf.jena.parser.version>
@@ -52,10 +51,6 @@
     <jacoco.out.it.file>jacoco-it.exec</jacoco.out.it.file>
     <sonar.jacoco.reportPath>${jacoco.outputDir}/${jacoco.out.unit.file}</sonar.jacoco.reportPath>
     <sonar.jacoco.itReportPath>${jacoco.outputDir}/${jacoco.out.it.file}</sonar.jacoco.itReportPath>
-    <!-- osgi -->
-    <camel.osgi.import.before.defaults>org.apache.camel.spi;${camel.osgi.import.strict.version}</camel.osgi.import.before.defaults>
-    <camel.osgi.export.pkg>org.fcrepo.camel.*</camel.osgi.export.pkg>
-    <camel.osgi.export.service>org.apache.camel.spi.ComponentResolver;component=fcrepo</camel.osgi.export.service>
   </properties>
 
   <licenses>
@@ -140,12 +135,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <version>${javax.ws.rs.version}</version>
     </dependency>
 
     <!-- logging -->
@@ -621,7 +610,8 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Bundle-Name>${project.artifactId}</Bundle-Name>
+            <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>
               org.fcrepo.camel;version=${project.version},
               org.fcrepo.camel.processor;version=${project.version}
@@ -631,7 +621,6 @@
               com.google.thirdparty.publicsuffix.*,
               com.hp.hpl.jena.*,
               com.ibm.icu.*,
-              javax.ws.rs.*,
               org.apache.clerezza.rdf.*,
               org.apache.clerezza.utils.*,
               org.apache.commons.codec.*,
@@ -640,6 +629,8 @@
               org.osgi.service.component,
               org.wymiwyg.commons.util.*,
             </Private-Package>
+            <Implementation-Title>Fedora Repository - Camel</Implementation-Title>
+            <Implementation-Version>${project.version}</Implementation-Version>
           </instructions>
         </configuration>
       </plugin>
@@ -656,10 +647,6 @@
             </goals>
             <configuration>
               <properties>
-                <property>
-                  <name>jms.port</name>
-                  <value>${jms.port}</value>
-                </property>
                 <property>
                   <name>integration-test</name>
                   <value>true</value>

--- a/src/main/java/org/fcrepo/camel/FcrepoClient.java
+++ b/src/main/java/org/fcrepo/camel/FcrepoClient.java
@@ -24,8 +24,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.ws.rs.core.Link;
-
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
@@ -292,7 +290,7 @@ public class FcrepoClient {
         final List<URI> uris = new ArrayList<URI>();
         final Header[] links = response.getHeaders("Link");
         for (Header header: links) {
-            final Link link = Link.valueOf(header.getValue());
+            final FcrepoLink link = new FcrepoLink(header.getValue());
             if (link.getRel().equals(relationship)) {
                 uris.add(link.getUri());
             }

--- a/src/main/java/org/fcrepo/camel/FcrepoLink.java
+++ b/src/main/java/org/fcrepo/camel/FcrepoLink.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2014 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.camel;
+
+import java.net.URI;
+
+/**
+ * A class representing the value of an HTTP Link header
+ *
+ * @author Aaron Coburn
+ */
+class FcrepoLink {
+
+    private static final String LINK_DELIM = ";";
+
+    private static final String META_REL = "rel";
+
+    private URI uri;
+
+    private String rel;
+
+    /**
+     * Create a representation of a Link header.
+     */
+    public FcrepoLink(final String link) {
+        parse(link);
+    }
+
+    /**
+     * Retrieve the URI of the link
+     * @return URI
+     */
+    public URI getUri() {
+        return uri;
+    }
+
+    /**
+     * Retrieve the REL portion of the link.
+     * @return String
+     */
+    public String getRel() {
+        return rel;
+    }
+
+    /**
+     * Parse the value of a link header
+     */
+    private void parse(final String link) {
+        if (link != null) {
+            final String[] segments = link.split(LINK_DELIM);
+            if (segments.length == 2) {
+                uri = getLinkPart(segments[0]);
+                if (uri != null) {
+                    rel = getRelPart(segments[1]);
+                }
+            }
+        }
+    }
+
+    /**
+     * Extract the rel="..." part of the link header
+     */
+    private static String getRelPart(final String relPart) {
+        final String[] segments = relPart.trim().split("=");
+        if (segments.length != 2 || !META_REL.equals(segments[0])) {
+            return null;
+        }
+        final String relValue = segments[1];
+        if (relValue.startsWith("\"") && relValue.endsWith("\"")) {
+            return relValue.substring(1, relValue.length() - 1);
+        } else {
+            return relValue;
+        }
+    }
+
+    /**
+     * Extract the URI part of the link header
+     */
+    private static URI getLinkPart(final String uriPart) {
+        final String linkPart = uriPart.trim();
+        if (!linkPart.startsWith("<") || !linkPart.endsWith(">")) {
+            return null;
+        } else {
+            return URI.create(linkPart.substring(1, linkPart.length() - 1));
+        }
+    }
+}

--- a/src/test/java/org/fcrepo/camel/FcrepoLinkTest.java
+++ b/src/test/java/org/fcrepo/camel/FcrepoLinkTest.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2014 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.camel;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * @author acoburn
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class FcrepoLinkTest {
+
+    @Test
+    public void testLink() {
+        final String url = "http://localhost/rest/a/b/c";
+        final String rel = "describedby";
+        final String header = String.format("<%s>; rel=\"%s\"", url, rel);
+        final FcrepoLink link = new FcrepoLink(header);
+        assertEquals(URI.create(url), link.getUri());
+        assertEquals(url, link.getUri().toString());
+        assertEquals(rel, link.getRel());
+    }
+
+    @Test
+    public void testLinkNoQuotes() {
+        final String url = "http://localhost/rest/a/b/c";
+        final String rel = "describedby";
+        final String header = String.format("<%s>; rel=%s", url, rel);
+        final FcrepoLink link = new FcrepoLink(header);
+        assertEquals(URI.create(url), link.getUri());
+        assertEquals(url, link.getUri().toString());
+        assertEquals(rel, link.getRel());
+    }
+
+    @Test
+    public void testLinkNoBrackets() {
+        final String url = "http://localhost/rest/a/b/c";
+        final String rel = "describedby";
+        final String header = String.format("%s; rel=%s", url, rel);
+        final FcrepoLink link = new FcrepoLink(header);
+        assertEquals(null, link.getUri());
+        assertEquals(null, link.getRel());
+    }
+
+    @Test
+    public void testLinkBadBrackets1() {
+        final String url = "http://localhost/rest/a/b/c";
+        final String rel = "describedby";
+        final String header = String.format("<%s; rel=%s", url, rel);
+        final FcrepoLink link = new FcrepoLink(header);
+        assertEquals(null, link.getUri());
+        assertEquals(null, link.getRel());
+    }
+
+    @Test
+    public void testLinkBadBrackets2() {
+        final String url = "http://localhost/rest/a/b/c";
+        final String rel = "describedby";
+        final String header = String.format("%s>; rel=%s", url, rel);
+        final FcrepoLink link = new FcrepoLink(header);
+        assertEquals(null, link.getUri());
+        assertEquals(null, link.getRel());
+    }
+
+    @Test
+    public void testLinkBadQuotes() {
+        final String url = "http://localhost/rest/a/b/c";
+        final String rel = "describedby";
+        final String header = String.format("<%s>; rel=\"%s", url, rel);
+        final FcrepoLink link = new FcrepoLink(header);
+        assertEquals(URI.create(url), link.getUri());
+        assertEquals("\"" + rel, link.getRel());
+    }
+
+
+    @Test
+    public void testNullLink() {
+        final FcrepoLink link = new FcrepoLink(null);
+        assertEquals(null, link.getUri());
+        assertEquals(null, link.getRel());
+    }
+
+    @Test
+    public void testMultipleSegments() {
+        final FcrepoLink link = new FcrepoLink("<a>; rel=foo; rel=bar");
+        assertEquals(null, link.getUri());
+        assertEquals(null, link.getRel());
+    }
+
+    @Test
+    public void testMultipleMeta() {
+        final FcrepoLink link = new FcrepoLink("<a>; rel=foo=bar");
+        assertEquals(URI.create("a"), link.getUri());
+        assertEquals(null, link.getRel());
+    }
+
+    @Test
+    public void testNotMetaRel() {
+        final FcrepoLink link = new FcrepoLink("<a>; foo=bar");
+        assertEquals(URI.create("a"), link.getUri());
+        assertEquals(null, link.getRel());
+    }
+}


### PR DESCRIPTION
https://jira.duraspace.org/browse/FCREPO-1281

There were issues with the OSGi bundling of fcrepo-camel such that the jersey libraries were not found by bundles implementing fcrepo-based routes. This PR removes the dependency on jersey (which consisted entirely in using it to parse HTTP Link headers). Now those headers are parsed manually.