### PR TITLE
RDF parser should define a context path

### DIFF
--- a/src/main/java/org/fcrepo/camel/processor/SparqlInsertProcessor.java
+++ b/src/main/java/org/fcrepo/camel/processor/SparqlInsertProcessor.java
@@ -24,6 +24,7 @@ import org.apache.camel.Message;
 import org.apache.clerezza.rdf.core.serializedform.ParsingProvider;
 import org.apache.clerezza.rdf.core.serializedform.SerializingProvider;
 import org.apache.clerezza.rdf.core.MGraph;
+import org.apache.clerezza.rdf.core.UriRef;
 import org.apache.clerezza.rdf.core.impl.SimpleMGraph;
 import org.apache.clerezza.rdf.jena.parser.JenaParserProvider;
 import org.apache.clerezza.rdf.jena.serializer.JenaSerializerProvider;
@@ -51,9 +52,13 @@ public class SparqlInsertProcessor implements Processor {
         final MGraph graph = new SimpleMGraph();
         final String contentType = in.getHeader(Exchange.CONTENT_TYPE, String.class);
         final ByteArrayOutputStream serializedGraph = new ByteArrayOutputStream();
+        final String subject = ProcessorUtils.getSubjectUri(in);
 
+        /* the text/rdf+nt mimetype will be removed in the next version of clerezza
+         * at which point they will be using application/n-triples. Once that happens,
+         * this ternary expression can be removed. */
         parser.parse(graph, in.getBody(InputStream.class),
-                "application/n-triples".equals(contentType) ? "text/rdf+nt" : contentType, null);
+                "application/n-triples".equals(contentType) ? "text/rdf+nt" : contentType, new UriRef(subject));
         serializer.serialize(serializedGraph, graph.getGraph(), "text/rdf+nt");
 
         exchange.getIn().setBody("update=INSERT DATA { " + serializedGraph.toString("UTF-8") + " }");

--- a/src/main/java/org/fcrepo/camel/processor/SparqlUpdateProcessor.java
+++ b/src/main/java/org/fcrepo/camel/processor/SparqlUpdateProcessor.java
@@ -24,6 +24,7 @@ import org.apache.camel.Message;
 import org.apache.clerezza.rdf.core.serializedform.ParsingProvider;
 import org.apache.clerezza.rdf.core.serializedform.SerializingProvider;
 import org.apache.clerezza.rdf.core.MGraph;
+import org.apache.clerezza.rdf.core.UriRef;
 import org.apache.clerezza.rdf.core.impl.SimpleMGraph;
 import org.apache.clerezza.rdf.jena.parser.JenaParserProvider;
 import org.apache.clerezza.rdf.jena.serializer.JenaSerializerProvider;
@@ -53,8 +54,11 @@ public class SparqlUpdateProcessor implements Processor {
         final ByteArrayOutputStream serializedGraph = new ByteArrayOutputStream();
         final String subject = ProcessorUtils.getSubjectUri(in);
 
+        /* the text/rdf+nt mimetype will be removed in the next version of clerezza
+         * at which point they will be using application/n-triples. Once that happens,
+         * this ternary expression can be removed. */
         parser.parse(graph, in.getBody(InputStream.class),
-                "application/n-triples".equals(contentType) ? "text/rdf+nt" : contentType, null);
+                "application/n-triples".equals(contentType) ? "text/rdf+nt" : contentType, new UriRef(subject));
         serializer.serialize(serializedGraph, graph.getGraph(), "text/rdf+nt");
 
         /*

--- a/src/test/java/org/fcrepo/camel/SparqlInsertProcessorTest.java
+++ b/src/test/java/org/fcrepo/camel/SparqlInsertProcessorTest.java
@@ -51,7 +51,7 @@ public class SparqlInsertProcessorTest extends CamelTestSupport {
     @Test
     public void testDescribe() throws IOException, InterruptedException {
         final String base = "http://localhost/rest";
-        final String path = "/path/a/b/c/d";
+        final String path = "/path/a/b/c";
         final String document = getN3Document();
 
         // Assertions
@@ -60,6 +60,7 @@ public class SparqlInsertProcessorTest extends CamelTestSupport {
         for (final String s : document.split("\n")) {
             resultEndpoint.expectedBodyReceived().body().contains(s);
         }
+        resultEndpoint.expectedBodyReceived().body().contains("<" + base + path + "> dc:title \"some title\" .");
         resultEndpoint.expectedHeaderReceived("Content-Type", "application/x-www-form-urlencoded");
         resultEndpoint.expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
 

--- a/src/test/java/org/fcrepo/camel/SparqlUpdateProcessorTest.java
+++ b/src/test/java/org/fcrepo/camel/SparqlUpdateProcessorTest.java
@@ -67,6 +67,7 @@ public class SparqlUpdateProcessorTest extends CamelTestSupport {
         for (final String s : document.split("\n")) {
             resultEndpoint.expectedBodyReceived().body().contains(s);
         }
+        resultEndpoint.expectedBodyReceived().body().contains("<" + base + path + "> dc:title \"some title\" .");
         resultEndpoint.expectedHeaderReceived("Content-Type", "application/x-www-form-urlencoded");
         resultEndpoint.expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/FCREPO-1280

added baseUri parameter to rdf parser classes
added documentation on the use of text/rdf+nt contentType